### PR TITLE
Weighted Random LB Impl Optimization via Vose Alias

### DIFF
--- a/balancer/weightedtarget/weightedtarget.go
+++ b/balancer/weightedtarget/weightedtarget.go
@@ -42,7 +42,7 @@ const Name = "weighted_target_experimental"
 
 // NewRandomWRR is the WRR constructor used to pick sub-pickers from
 // sub-balancers. It's to be modified in tests.
-var NewRandomWRR = wrr.NewRandom
+var NewRandomWRR = wrr.NewAlias
 
 func init() {
 	balancer.Register(bb{})

--- a/internal/wrr/alias.go
+++ b/internal/wrr/alias.go
@@ -29,6 +29,7 @@ type aliasWRR struct {
 	equalWeights bool
 }
 
+// NewAlias creates a new WRR with aliasing.
 func NewAlias() WRR {
 	return &aliasWRR{equalWeights: true}
 }

--- a/internal/wrr/alias.go
+++ b/internal/wrr/alias.go
@@ -1,0 +1,134 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wrr
+
+import (
+	"fmt"
+	rand "math/rand/v2"
+)
+
+type aliasWRR struct {
+	items        []*weightedItem
+	alias        []int
+	prob         []float64
+	equalWeights bool
+}
+
+func NewAlias() WRR {
+	return &aliasWRR{equalWeights: true}
+}
+
+func (aw *aliasWRR) Add(item any, weight int64) {
+	if len(aw.items) > 0 && aw.equalWeights {
+		if weight != aw.items[0].weight {
+			aw.equalWeights = false
+		}
+	}
+	aw.items = append(aw.items, &weightedItem{item: item, weight: weight})
+	if !aw.equalWeights {
+		aw.buildAliasTable()
+	}
+}
+
+func (aw *aliasWRR) Next() any {
+	if len(aw.items) == 0 {
+		return nil
+	}
+
+	if aw.equalWeights {
+		return aw.items[rand.IntN(len(aw.items))].item
+	}
+
+	n := len(aw.items)
+	i := rand.IntN(n)
+	r := rand.Float64()
+
+	if r < aw.prob[i] {
+		return aw.items[i].item
+	}
+	return aw.items[aw.alias[i]].item
+}
+
+func (aw *aliasWRR) buildAliasTable() {
+	n := len(aw.items)
+	if n == 0 {
+		return
+	}
+
+	totalWeight := int64(0)
+	for _, item := range aw.items {
+		totalWeight += item.weight
+	}
+
+	aw.prob = make([]float64, n)
+	aw.alias = make([]int, n)
+
+	// small and large are stacks of indices
+	small := make([]int, 0, n)
+	large := make([]int, 0, n)
+
+	// Scale probabilities so that average is 1.0
+	avgWeight := float64(totalWeight) / float64(n)
+
+	for i, item := range aw.items {
+		if avgWeight == 0 {
+			aw.prob[i] = 0
+		} else {
+			aw.prob[i] = float64(item.weight) / avgWeight
+		}
+
+		if aw.prob[i] < 1.0 {
+			small = append(small, i)
+		} else {
+			large = append(large, i)
+		}
+	}
+
+	for len(small) > 0 && len(large) > 0 {
+		l := small[len(small)-1]
+		small = small[:len(small)-1]
+
+		g := large[len(large)-1]
+		large = large[:len(large)-1]
+
+		aw.alias[l] = g
+		aw.prob[g] = (aw.prob[g] + aw.prob[l]) - 1.0
+
+		if aw.prob[g] < 1.0 {
+			small = append(small, g)
+		} else {
+			large = append(large, g)
+		}
+	}
+
+	for len(large) > 0 {
+		g := large[len(large)-1]
+		large = large[:len(large)-1]
+		aw.prob[g] = 1.0
+	}
+
+	for len(small) > 0 {
+		l := small[len(small)-1]
+		small = small[:len(small)-1]
+		aw.prob[l] = 1.0
+	}
+}
+
+func (aw *aliasWRR) String() string {
+	return fmt.Sprint(aw.items)
+}

--- a/internal/wrr/alias_test.go
+++ b/internal/wrr/alias_test.go
@@ -1,0 +1,95 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wrr
+
+import (
+	rand "math/rand/v2"
+	"strconv"
+	"testing"
+)
+
+func (s) TestAliasWRRNext(t *testing.T) {
+	testWRRNext(t, NewAlias)
+}
+
+func BenchmarkAliasWRRNext(b *testing.B) {
+	for _, n := range []int{100, 500, 1000} {
+		b.Run("equal-weights-"+strconv.Itoa(n)+"-items", func(b *testing.B) {
+			w := NewAlias()
+			sumOfWeights := n
+			for i := 0; i < n; i++ {
+				w.Add(i, 1)
+			}
+			w.Next()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for i := 0; i < sumOfWeights; i++ {
+					w.Next()
+				}
+			}
+		})
+	}
+
+	var maxWeight int64 = 1024
+	for _, n := range []int{100, 500, 1000} {
+		b.Run("random-weights-"+strconv.Itoa(n)+"-items", func(b *testing.B) {
+			w := NewAlias()
+			var sumOfWeights int64
+			for i := 0; i < n; i++ {
+				weight := rand.Int64N(maxWeight + 1)
+				w.Add(i, weight)
+				sumOfWeights += weight
+			}
+			w.Next()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for i := 0; i < int(sumOfWeights); i++ {
+					w.Next()
+				}
+			}
+		})
+	}
+
+	itemsNum := 200
+	heavyWeight := int64(itemsNum)
+	lightWeight := int64(1)
+	heavyIndices := []int{0, itemsNum / 2, itemsNum - 1}
+	for _, heavyIndex := range heavyIndices {
+		b.Run("skew-weights-heavy-index-"+strconv.Itoa(heavyIndex), func(b *testing.B) {
+			w := NewAlias()
+			var sumOfWeights int64
+			for i := 0; i < itemsNum; i++ {
+				var weight int64
+				if i == heavyIndex {
+					weight = heavyWeight
+				} else {
+					weight = lightWeight
+				}
+				sumOfWeights += weight
+				w.Add(i, weight)
+			}
+			w.Next()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for i := 0; i < int(sumOfWeights); i++ {
+					w.Next()
+				}
+			}
+		})
+	}
+}

--- a/internal/wrr/wrr_comparison_test.go
+++ b/internal/wrr/wrr_comparison_test.go
@@ -1,0 +1,60 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wrr
+
+import (
+	"fmt"
+	rand "math/rand/v2"
+	"testing"
+)
+
+func BenchmarkWRR_Comparison(b *testing.B) {
+	counts := []int{10, 100, 1000, 10000}
+
+	maxWeight := int64(100)
+
+	for _, count := range counts {
+		weights := make([]int64, count)
+		for i := 0; i < count; i++ {
+			weights[i] = rand.Int64N(maxWeight) + 1
+		}
+
+		b.Run(fmt.Sprintf("Random_O_logN_N=%d", count), func(b *testing.B) {
+			w := NewRandom()
+			for i, weight := range weights {
+				w.Add(i, weight)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				w.Next()
+			}
+		})
+
+		b.Run(fmt.Sprintf("Alias_O_1_N=%d", count), func(b *testing.B) {
+			w := NewAlias()
+			for i, weight := range weights {
+				w.Add(i, weight)
+			}
+			w.Next()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				w.Next()
+			}
+		})
+	}
+}

--- a/internal/wrr/wrr_test.go
+++ b/internal/wrr/wrr_test.go
@@ -36,7 +36,7 @@ func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
 
-const iterCount = 100000
+const iterCount = 10000
 
 func equalApproximate(a, b float64) error {
 	opt := cmp.Comparer(func(x, y float64) bool {

--- a/internal/wrr/wrr_test.go
+++ b/internal/wrr/wrr_test.go
@@ -36,7 +36,7 @@ func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
 
-const iterCount = 10000
+const iterCount = 100000
 
 func equalApproximate(a, b float64) error {
 	opt := cmp.Comparer(func(x, y float64) bool {


### PR DESCRIPTION
### Description

Using ***Vose Alias*** method for ***Weighted Random LB Implemention***. 

This improves the `hot RPC path` processing which is the `Next()` function by reducing the time complexity from `O(log(n))` (binary search) to `O(1)`.

https://www.keithschwarz.com/darts-dice-coins/
https://en.wikipedia.org/wiki/Alias_method

### Benchmarking Tests

#### Existing Tests

```sh
go test -bench=WRRNext$ -benchmem -v ./internal/wrr/...
```  

```
| Test Case                   | Alias WRR (ns/op) | Random WRR (ns/op) | Improvement (%) |
| --------------------------- | ----------------- | ------------------ | --------------- |
| Equal Weights (100 items)   | 974.9             | 765.5              | -27.30%        |
| Equal Weights (500 items)   | 4,862             | 3,757              | -29.40%        |
| Equal Weights (1000 items)  | 9,708             | 7,538              | -28.70%        |
| Random Weights (100 items)  | 1,138,908         | 2,172,821          | +47.5%          |
| Random Weights (500 items)  | 5,586,565         | 13,563,017         | +58.8%          |
| Random Weights (1000 items) | 12,055,633        | 30,958,466         | +61.0%          |
| Skew Weights (Index 0)      | 9,585             | 12,330             | +22.2%          |
| Skew Weights (Index 100)    | 9,643             | 12,450             | +22.5%          |
| Skew Weights (Index 199)    | 9,597             | 12,589             | +23.7%          |
```

#### New Comparison Tests

```sh
go test -bench=BenchmarkWRR_Comparison -benchmem -v ./internal/wrr/...
```

```
| Item Count (N) | Random O(logN) (ns/op) | Alias O(1) (ns/op) | Improvement (%) |
| -------------- | ---------------------- | ------------------ | --------------- |
| 10             | 25.06                  | 20.97              | +16.3%          |
| 100            | 40.77                  | 23.77              | +41.7%          |
| 1,000          | 61.37                  | 23.56              | +61.6%          |
| 10,000         | 96.64                  | 28.91              | +70.1%          |
```

### Performance Improvement Overall

On average, the Alias implementation provides a **14.59%** performance improvement over the Random implementation across all tested scenarios.

### Notes

* Time complexity of `Add` would be more - but that is not in RPC path and not that frequently called.
* Does this need a gRFC?


RELEASE NOTES:
* Using `Vose Alias` for Weighted Random LB Impl. 